### PR TITLE
Poll the server for JWT validity (deleting cookies)

### DIFF
--- a/backend/graphql-server/dist/resolvers.js
+++ b/backend/graphql-server/dist/resolvers.js
@@ -94,6 +94,19 @@ const resolvers = {
                 throw error;
             }
         },
+        checkSession(_, __, { req }) {
+            // Middleware is responsible for validating JWTs
+            if (req.userUid) {
+                const user = knexInstance("users").where({ uid: req.userUid }).first();
+                return {
+                    isValid: true,
+                    user,
+                };
+            }
+            else {
+                return { isValid: false };
+            }
+        },
     },
     // Resolvers to gather nested fields within a User query (EX: User{ workouts{...} })
     User: {
@@ -361,33 +374,6 @@ const resolvers = {
                 throw error;
             }
         },
-        // async deleteWorkout(_, { uid }: { uid: String }) {
-        //   try {
-        //     const exercisesCount = Number(
-        //       (
-        //         await knexInstance("exercises")
-        //           .count("*")
-        //           .where({ workoutUid: uid })
-        //           .first()
-        //       ).count
-        //     );
-        //     if (exercisesCount > 0) {
-        //       throw new Error(
-        //         `Please delete the ${exercisesCount} exercises associated with this workout before deleting the workout. Exiting without deleting workout.`
-        //       );
-        //     }
-        //     const numAffectedRows = await knexInstance("workouts")
-        //       .where({ uid: uid })
-        //       .del();
-        //     console.log(
-        //       `${numAffectedRows} rows affected in deleteWorkout mutation.`
-        //     );
-        //     return await knexInstance("workouts").select("*");
-        //   } catch (error) {
-        //     console.error("Error deleting workout:", error);
-        //     throw error;
-        //   }
-        // },
         async deleteExercise(_, { uid }, { req }) {
             if (!req.userUid) {
                 throw new NotAuthorizedError();

--- a/backend/graphql-server/src/generated/backend-types.ts
+++ b/backend/graphql-server/src/generated/backend-types.ts
@@ -56,6 +56,12 @@ export type AddWorkoutWithExercisesInput = {
   exercises: Array<InputMaybe<AddExerciseInput>>;
 };
 
+export type CheckSessionResponse = {
+  __typename?: 'CheckSessionResponse';
+  isValid: Scalars['Boolean']['output'];
+  user?: Maybe<User>;
+};
+
 export type EditExerciseInput = {
   comment?: InputMaybe<Scalars['String']['input']>;
   elapsedSeconds?: InputMaybe<Scalars['Int']['input']>;
@@ -182,6 +188,7 @@ export type MutationUpdateWorkoutArgs = {
 
 export type Query = {
   __typename?: 'Query';
+  checkSession: CheckSessionResponse;
   exercise?: Maybe<Exercise>;
   exercises?: Maybe<Array<Maybe<Exercise>>>;
   user?: Maybe<User>;
@@ -312,6 +319,7 @@ export type ResolversTypes = ResolversObject<{
   AddUserInput: AddUserInput;
   AddWorkoutWithExercisesInput: AddWorkoutWithExercisesInput;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
+  CheckSessionResponse: ResolverTypeWrapper<CheckSessionResponse>;
   EditExerciseInput: EditExerciseInput;
   EditUserInput: EditUserInput;
   Exercise: ResolverTypeWrapper<Exercise>;
@@ -334,6 +342,7 @@ export type ResolversParentTypes = ResolversObject<{
   AddUserInput: AddUserInput;
   AddWorkoutWithExercisesInput: AddWorkoutWithExercisesInput;
   Boolean: Scalars['Boolean']['output'];
+  CheckSessionResponse: CheckSessionResponse;
   EditExerciseInput: EditExerciseInput;
   EditUserInput: EditUserInput;
   Exercise: Exercise;
@@ -346,6 +355,12 @@ export type ResolversParentTypes = ResolversObject<{
   String: Scalars['String']['output'];
   User: User;
   Workout: Workout;
+}>;
+
+export type CheckSessionResponseResolvers<ContextType = any, ParentType extends ResolversParentTypes['CheckSessionResponse'] = ResolversParentTypes['CheckSessionResponse']> = ResolversObject<{
+  isValid?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type ExerciseResolvers<ContextType = any, ParentType extends ResolversParentTypes['Exercise'] = ResolversParentTypes['Exercise']> = ResolversObject<{
@@ -382,6 +397,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
 }>;
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
+  checkSession?: Resolver<ResolversTypes['CheckSessionResponse'], ParentType, ContextType>;
   exercise?: Resolver<Maybe<ResolversTypes['Exercise']>, ParentType, ContextType, RequireFields<QueryExerciseArgs, 'uid'>>;
   exercises?: Resolver<Maybe<Array<Maybe<ResolversTypes['Exercise']>>>, ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'uid'>>;
@@ -420,6 +436,7 @@ export type WorkoutResolvers<ContextType = any, ParentType extends ResolversPare
 }>;
 
 export type Resolvers<ContextType = any> = ResolversObject<{
+  CheckSessionResponse?: CheckSessionResponseResolvers<ContextType>;
   Exercise?: ExerciseResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;

--- a/backend/graphql-server/src/resolvers.ts
+++ b/backend/graphql-server/src/resolvers.ts
@@ -110,6 +110,19 @@ const resolvers = {
         throw error;
       }
     },
+
+    checkSession(_, __, { req }) {
+      // Middleware is responsible for validating JWTs
+      if (req.userUid) {
+        const user = knexInstance("users").where({ uid: req.userUid }).first();
+        return {
+          isValid: true,
+          user,
+        };
+      } else {
+        return { isValid: false };
+      }
+    },
   },
 
   // Resolvers to gather nested fields within a User query (EX: User{ workouts{...} })
@@ -457,38 +470,6 @@ const resolvers = {
         throw error;
       }
     },
-
-    // async deleteWorkout(_, { uid }: { uid: String }) {
-    //   try {
-    //     const exercisesCount = Number(
-    //       (
-    //         await knexInstance("exercises")
-    //           .count("*")
-    //           .where({ workoutUid: uid })
-    //           .first()
-    //       ).count
-    //     );
-
-    //     if (exercisesCount > 0) {
-    //       throw new Error(
-    //         `Please delete the ${exercisesCount} exercises associated with this workout before deleting the workout. Exiting without deleting workout.`
-    //       );
-    //     }
-
-    //     const numAffectedRows = await knexInstance("workouts")
-    //       .where({ uid: uid })
-    //       .del();
-
-    //     console.log(
-    //       `${numAffectedRows} rows affected in deleteWorkout mutation.`
-    //     );
-
-    //     return await knexInstance("workouts").select("*");
-    //   } catch (error) {
-    //     console.error("Error deleting workout:", error);
-    //     throw error;
-    //   }
-    // },
 
     async deleteExercise(_, { uid }: { uid: String }, { req }: any) {
       if (!req.userUid) {

--- a/backend/graphql-server/src/schema.graphql
+++ b/backend/graphql-server/src/schema.graphql
@@ -33,6 +33,11 @@ type Exercise {
   elapsedSeconds: Int
 }
 
+type CheckSessionResponse {
+  isValid: Boolean!
+  user: User
+}
+
 # Required: Defines the entry points to the graph
 type Query {
   users: [User]
@@ -41,6 +46,8 @@ type Query {
   workout(uid: ID!): Workout
   exercises: [Exercise]
   exercise(uid: ID!): Exercise
+
+  checkSession: CheckSessionResponse!
 }
 
 type RefreshTokenResponse {

--- a/frontend/kettlepal-fe/package-lock.json
+++ b/frontend/kettlepal-fe/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react": "^18.2.79",
         "@types/react-dom": "^18.2.25",
         "framer-motion": "^6.5.1",
+        "js-cookie": "^3.0.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^3.11.0",
@@ -13274,6 +13275,14 @@
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/frontend/kettlepal-fe/package.json
+++ b/frontend/kettlepal-fe/package.json
@@ -15,6 +15,7 @@
     "@types/react": "^18.2.79",
     "@types/react-dom": "^18.2.25",
     "framer-motion": "^6.5.1",
+    "js-cookie": "^3.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^3.11.0",

--- a/frontend/kettlepal-fe/src/App.tsx
+++ b/frontend/kettlepal-fe/src/App.tsx
@@ -8,10 +8,12 @@ import Login from "./Pages/Login";
 import Tray from "./Components/Tray";
 import { UserProvider } from "./Contexts/UserContext";
 import PrivateRoute from "./Components/Auth/PrivateRoute";
+import SessionChecker from "./Components/Auth/SessionChecker";
 
 export const App = () => (
   <ChakraProvider theme={theme}>
     <UserProvider>
+      <SessionChecker />
       <Box
         h="calc(100vh - 3rem)"
         overflowY={"scroll"}

--- a/frontend/kettlepal-fe/src/Components/Auth/SessionChecker.tsx
+++ b/frontend/kettlepal-fe/src/Components/Auth/SessionChecker.tsx
@@ -1,0 +1,6 @@
+import { useCheckSession } from "../../Hooks/useCheckSession";
+
+export default function SessionChecker() {
+  useCheckSession();
+  return null;
+}

--- a/frontend/kettlepal-fe/src/Components/NewWorkouts/CreateWorkout.tsx
+++ b/frontend/kettlepal-fe/src/Components/NewWorkouts/CreateWorkout.tsx
@@ -339,7 +339,7 @@ export default function CreateWorkout() {
           {state.exercises.map((exercise, index) => {
             return (
               <motion.div
-                key={`${exercise.key}`} //
+                key={`${exercise.key}`}
                 initial={{ opacity: 0, x: 200 }}
                 animate={{ opacity: 1, x: 0 }}
                 exit={{ opacity: 0, x: -200 }}
@@ -427,11 +427,11 @@ export default function CreateWorkout() {
                     <br />
                   </>
                 )}
-                {state.exercises.map((exercise) => {
+                {state.exercises.map((exercise, index) => {
                   return (
-                    <>
+                    <React.Fragment key={index}>
                       {formatExerciseString(exercise)} <br />
-                    </>
+                    </React.Fragment>
                   );
                 })}
               </>

--- a/frontend/kettlepal-fe/src/Hooks/useCheckSession.ts
+++ b/frontend/kettlepal-fe/src/Hooks/useCheckSession.ts
@@ -1,0 +1,15 @@
+import { useUser } from "../Contexts/UserContext";
+import { useCheckSessionQuery } from "../generated/frontend-types";
+
+// The server handles authentication access with HTTP-Only JWT tokens.
+// The client keeps track in state. However, if a user clears their
+// cookies, the server knows, but the UserContext doesn't. Here,
+// we're polling the server to keep client state in sync with the server.
+
+export function useCheckSession() {
+  const { user } = useUser();
+  return useCheckSessionQuery({
+    fetchPolicy: "network-only",
+    pollInterval: user ? 12 * 60 * 1000 : 0, // 12mins if logged in.
+  });
+}

--- a/frontend/kettlepal-fe/src/Pages/Login.tsx
+++ b/frontend/kettlepal-fe/src/Pages/Login.tsx
@@ -42,8 +42,8 @@ export default function Login() {
 
   const [loginMutation, { loading, error }] = useLoginMutation({
     onCompleted: (data) => {
-      if (data.login) {
-        login(data.login);
+      if (data?.login) {
+        login();
         navigate("/new-workout");
       } else {
         console.error("Login failed: ", error);

--- a/frontend/kettlepal-fe/src/generated/frontend-types.ts
+++ b/frontend/kettlepal-fe/src/generated/frontend-types.ts
@@ -57,6 +57,12 @@ export type AddWorkoutWithExercisesInput = {
   exercises: Array<InputMaybe<AddExerciseInput>>;
 };
 
+export type CheckSessionResponse = {
+  __typename?: 'CheckSessionResponse';
+  isValid: Scalars['Boolean']['output'];
+  user?: Maybe<User>;
+};
+
 export type EditExerciseInput = {
   comment?: InputMaybe<Scalars['String']['input']>;
   elapsedSeconds?: InputMaybe<Scalars['Int']['input']>;
@@ -183,6 +189,7 @@ export type MutationUpdateWorkoutArgs = {
 
 export type Query = {
   __typename?: 'Query';
+  checkSession: CheckSessionResponse;
   exercise?: Maybe<Exercise>;
   exercises?: Maybe<Array<Maybe<Exercise>>>;
   user?: Maybe<User>;
@@ -235,6 +242,19 @@ export type Workout = {
   userUid: Scalars['ID']['output'];
 };
 
+export type LoginMutationVariables = Exact<{
+  email: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+}>;
+
+
+export type LoginMutation = { __typename?: 'Mutation', login?: { __typename?: 'User', uid: string } | null };
+
+export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
+
+
+export type LogoutMutation = { __typename?: 'Mutation', invalidateToken: boolean };
+
 export type AddWorkoutWithExercisesMutationVariables = Exact<{
   userUid: Scalars['ID']['input'];
   workoutWithExercises: AddWorkoutWithExercisesInput;
@@ -243,25 +263,12 @@ export type AddWorkoutWithExercisesMutationVariables = Exact<{
 
 export type AddWorkoutWithExercisesMutation = { __typename?: 'Mutation', addWorkoutWithExercises: { __typename?: 'Workout', uid: string, userUid: string, exercises?: Array<{ __typename?: 'Exercise', uid: string, title: string }> | null } };
 
-export type LogoutMutationVariables = Exact<{ [key: string]: never; }>;
-
-
-export type LogoutMutation = { __typename?: 'Mutation', invalidateToken: boolean };
-
 export type DeleteWorkoutWithExercisesMutationVariables = Exact<{
   workoutUid: Scalars['ID']['input'];
 }>;
 
 
 export type DeleteWorkoutWithExercisesMutation = { __typename?: 'Mutation', deleteWorkoutWithExercises: { __typename?: 'Workout', uid: string } };
-
-export type LoginMutationVariables = Exact<{
-  email: Scalars['String']['input'];
-  password: Scalars['String']['input'];
-}>;
-
-
-export type LoginMutation = { __typename?: 'Mutation', login?: { __typename?: 'User', uid: string, firstName: string, lastName: string, email: string, isAuthorized: boolean, createdAt: string } | null };
 
 export type UserWithWorkoutsQueryVariables = Exact<{
   uid: Scalars['ID']['input'];
@@ -270,7 +277,76 @@ export type UserWithWorkoutsQueryVariables = Exact<{
 
 export type UserWithWorkoutsQuery = { __typename?: 'Query', user?: { __typename?: 'User', firstName: string, lastName: string, workouts: Array<{ __typename?: 'Workout', uid: string, comment?: string | null, elapsedSeconds?: number | null, createdAt: string, exercises?: Array<{ __typename?: 'Exercise', uid: string, title: string, weight?: number | null, weightUnit?: string | null, sets?: number | null, reps?: number | null, repsDisplay?: string | null, comment?: string | null, elapsedSeconds?: number | null, createdAt: string }> | null } | null> } | null };
 
+export type CheckSessionQueryVariables = Exact<{ [key: string]: never; }>;
 
+
+export type CheckSessionQuery = { __typename?: 'Query', checkSession: { __typename?: 'CheckSessionResponse', isValid: boolean, user?: { __typename?: 'User', uid: string, firstName: string, lastName: string, email: string, isAuthorized: boolean, createdAt: string, tokenCount: number } | null } };
+
+
+export const LoginDocument = gql`
+    mutation Login($email: String!, $password: String!) {
+  login(email: $email, password: $password) {
+    uid
+  }
+}
+    `;
+export type LoginMutationFn = Apollo.MutationFunction<LoginMutation, LoginMutationVariables>;
+
+/**
+ * __useLoginMutation__
+ *
+ * To run a mutation, you first call `useLoginMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useLoginMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [loginMutation, { data, loading, error }] = useLoginMutation({
+ *   variables: {
+ *      email: // value for 'email'
+ *      password: // value for 'password'
+ *   },
+ * });
+ */
+export function useLoginMutation(baseOptions?: Apollo.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, options);
+      }
+export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
+export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
+export type LoginMutationOptions = Apollo.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
+export const LogoutDocument = gql`
+    mutation Logout {
+  invalidateToken
+}
+    `;
+export type LogoutMutationFn = Apollo.MutationFunction<LogoutMutation, LogoutMutationVariables>;
+
+/**
+ * __useLogoutMutation__
+ *
+ * To run a mutation, you first call `useLogoutMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useLogoutMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [logoutMutation, { data, loading, error }] = useLogoutMutation({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useLogoutMutation(baseOptions?: Apollo.MutationHookOptions<LogoutMutation, LogoutMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument, options);
+      }
+export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>;
+export type LogoutMutationResult = Apollo.MutationResult<LogoutMutation>;
+export type LogoutMutationOptions = Apollo.BaseMutationOptions<LogoutMutation, LogoutMutationVariables>;
 export const AddWorkoutWithExercisesDocument = gql`
     mutation addWorkoutWithExercises($userUid: ID!, $workoutWithExercises: AddWorkoutWithExercisesInput!) {
   addWorkoutWithExercises(
@@ -313,36 +389,6 @@ export function useAddWorkoutWithExercisesMutation(baseOptions?: Apollo.Mutation
 export type AddWorkoutWithExercisesMutationHookResult = ReturnType<typeof useAddWorkoutWithExercisesMutation>;
 export type AddWorkoutWithExercisesMutationResult = Apollo.MutationResult<AddWorkoutWithExercisesMutation>;
 export type AddWorkoutWithExercisesMutationOptions = Apollo.BaseMutationOptions<AddWorkoutWithExercisesMutation, AddWorkoutWithExercisesMutationVariables>;
-export const LogoutDocument = gql`
-    mutation Logout {
-  invalidateToken
-}
-    `;
-export type LogoutMutationFn = Apollo.MutationFunction<LogoutMutation, LogoutMutationVariables>;
-
-/**
- * __useLogoutMutation__
- *
- * To run a mutation, you first call `useLogoutMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useLogoutMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [logoutMutation, { data, loading, error }] = useLogoutMutation({
- *   variables: {
- *   },
- * });
- */
-export function useLogoutMutation(baseOptions?: Apollo.MutationHookOptions<LogoutMutation, LogoutMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument, options);
-      }
-export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>;
-export type LogoutMutationResult = Apollo.MutationResult<LogoutMutation>;
-export type LogoutMutationOptions = Apollo.BaseMutationOptions<LogoutMutation, LogoutMutationVariables>;
 export const DeleteWorkoutWithExercisesDocument = gql`
     mutation deleteWorkoutWithExercises($workoutUid: ID!) {
   deleteWorkoutWithExercises(workoutUid: $workoutUid) {
@@ -376,45 +422,6 @@ export function useDeleteWorkoutWithExercisesMutation(baseOptions?: Apollo.Mutat
 export type DeleteWorkoutWithExercisesMutationHookResult = ReturnType<typeof useDeleteWorkoutWithExercisesMutation>;
 export type DeleteWorkoutWithExercisesMutationResult = Apollo.MutationResult<DeleteWorkoutWithExercisesMutation>;
 export type DeleteWorkoutWithExercisesMutationOptions = Apollo.BaseMutationOptions<DeleteWorkoutWithExercisesMutation, DeleteWorkoutWithExercisesMutationVariables>;
-export const LoginDocument = gql`
-    mutation Login($email: String!, $password: String!) {
-  login(email: $email, password: $password) {
-    uid
-    firstName
-    lastName
-    email
-    isAuthorized
-    createdAt
-  }
-}
-    `;
-export type LoginMutationFn = Apollo.MutationFunction<LoginMutation, LoginMutationVariables>;
-
-/**
- * __useLoginMutation__
- *
- * To run a mutation, you first call `useLoginMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useLoginMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [loginMutation, { data, loading, error }] = useLoginMutation({
- *   variables: {
- *      email: // value for 'email'
- *      password: // value for 'password'
- *   },
- * });
- */
-export function useLoginMutation(baseOptions?: Apollo.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, options);
-      }
-export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
-export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
-export type LoginMutationOptions = Apollo.BaseMutationOptions<LoginMutation, LoginMutationVariables>;
 export const UserWithWorkoutsDocument = gql`
     query UserWithWorkouts($uid: ID!) {
   user(uid: $uid) {
@@ -474,3 +481,51 @@ export type UserWithWorkoutsQueryHookResult = ReturnType<typeof useUserWithWorko
 export type UserWithWorkoutsLazyQueryHookResult = ReturnType<typeof useUserWithWorkoutsLazyQuery>;
 export type UserWithWorkoutsSuspenseQueryHookResult = ReturnType<typeof useUserWithWorkoutsSuspenseQuery>;
 export type UserWithWorkoutsQueryResult = Apollo.QueryResult<UserWithWorkoutsQuery, UserWithWorkoutsQueryVariables>;
+export const CheckSessionDocument = gql`
+    query CheckSession {
+  checkSession {
+    isValid
+    user {
+      uid
+      firstName
+      lastName
+      email
+      isAuthorized
+      createdAt
+      tokenCount
+    }
+  }
+}
+    `;
+
+/**
+ * __useCheckSessionQuery__
+ *
+ * To run a query within a React component, call `useCheckSessionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCheckSessionQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCheckSessionQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useCheckSessionQuery(baseOptions?: Apollo.QueryHookOptions<CheckSessionQuery, CheckSessionQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CheckSessionQuery, CheckSessionQueryVariables>(CheckSessionDocument, options);
+      }
+export function useCheckSessionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CheckSessionQuery, CheckSessionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CheckSessionQuery, CheckSessionQueryVariables>(CheckSessionDocument, options);
+        }
+export function useCheckSessionSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<CheckSessionQuery, CheckSessionQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<CheckSessionQuery, CheckSessionQueryVariables>(CheckSessionDocument, options);
+        }
+export type CheckSessionQueryHookResult = ReturnType<typeof useCheckSessionQuery>;
+export type CheckSessionLazyQueryHookResult = ReturnType<typeof useCheckSessionLazyQuery>;
+export type CheckSessionSuspenseQueryHookResult = ReturnType<typeof useCheckSessionSuspenseQuery>;
+export type CheckSessionQueryResult = Apollo.QueryResult<CheckSessionQuery, CheckSessionQueryVariables>;

--- a/frontend/kettlepal-fe/src/graphql/mutations.tsx
+++ b/frontend/kettlepal-fe/src/graphql/mutations.tsx
@@ -8,11 +8,6 @@ const LOGIN_MUTATION = gql`
   mutation Login($email: String!, $password: String!) {
     login(email: $email, password: $password) {
       uid
-      firstName
-      lastName
-      email
-      isAuthorized
-      createdAt
     }
   }
 `;

--- a/frontend/kettlepal-fe/src/graphql/queries.tsx
+++ b/frontend/kettlepal-fe/src/graphql/queries.tsx
@@ -30,3 +30,20 @@ const USER_WITH_WORKOUTS_QUERY = gql`
     }
   }
 `;
+
+const CHECK_SESSION_QUERY = gql`
+  query CheckSession {
+    checkSession {
+      isValid
+      user {
+        uid
+        firstName
+        lastName
+        email
+        isAuthorized
+        createdAt
+        tokenCount
+      }
+    }
+  }
+`;

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -2250,6 +2250,12 @@
       "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
       "dev": true
     },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true
+    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -4070,6 +4076,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "dayjs": "^1.11.10",
         "framer-motion": "^11.3.29",
         "graphql": "^16.8.1",
+        "js-cookie": "^3.0.5",
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "pg": "^8.11.5",
@@ -19,7 +20,8 @@
         "@graphql-codegen/cli": "^5.0.2",
         "@graphql-codegen/typescript": "^4.0.9",
         "@graphql-codegen/typescript-operations": "^4.2.3",
-        "@graphql-codegen/typescript-react-apollo": "^4.3.2"
+        "@graphql-codegen/typescript-react-apollo": "^4.3.2",
+        "@types/js-cookie": "^3.0.6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2269,6 +2271,12 @@
       "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
       "dev": true
     },
+    "node_modules/@types/js-cookie": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
+      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
+      "dev": true
+    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -4089,6 +4097,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dayjs": "^1.11.10",
     "framer-motion": "^11.3.29",
     "graphql": "^16.8.1",
+    "js-cookie": "^3.0.5",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "pg": "^8.11.5",
@@ -15,6 +16,7 @@
     "@graphql-codegen/cli": "^5.0.2",
     "@graphql-codegen/typescript": "^4.0.9",
     "@graphql-codegen/typescript-operations": "^4.2.3",
-    "@graphql-codegen/typescript-react-apollo": "^4.3.2"
+    "@graphql-codegen/typescript-react-apollo": "^4.3.2",
+    "@types/js-cookie": "^3.0.6"
   }
 }


### PR DESCRIPTION
If a user deleted their cookies, the local storage and JWT validity would become out of sync - resulting in no access to the backend endpoint, but having a logged-in view. Since JWT's are HTTP-only, we need a separate request to validate if the session is still valid. As a quick solution, the client now polls the db every 12 mins to check JWT status if you're logged in. 