### PR TITLE
AtAGlance Weekly Range Selector

### DIFF
--- a/backend/graphql-server/dist/resolvers.js
+++ b/backend/graphql-server/dist/resolvers.js
@@ -253,49 +253,95 @@ export const resolvers = {
                 case "Week":
                 default:
                     const weeklyPeriod = "weekly";
+                    // const weeklyData: AtAGlanceData[] = (
+                    //   await knexInstance.raw(`
+                    //   WITH date_range AS (
+                    //     SELECT generate_series(
+                    //       DATE(SPLIT_PART(:${dateRange}, ',', 1))::date,
+                    //       DATE(SPLIT_PART(:${dateRange}, ',', 2))::date,
+                    //       interval '1 day'
+                    //     )::date AS day
+                    //   ),
+                    //   daily_elapsed_seconds AS (
+                    //     SELECT
+                    //       w.date::date,
+                    //       SUM(w."elapsedSeconds") AS elapsedSeconds
+                    //     FROM workouts w
+                    //     WHERE w."userUid" = '${parent.uid}'
+                    //       AND w.date::date >= DATE(SPLIT_PART(:${dateRange}, ',', 1))::date
+                    //       AND w.date::date <= DATE(SPLIT_PART(:${dateRange}, ',', 2))::date
+                    //     GROUP BY w.date::date
+                    //   ),
+                    //   daily_work_capacity AS (
+                    //     SELECT
+                    //       w.date::date,
+                    //       SUM(
+                    //         CASE
+                    //           WHEN e."weightUnit" = 'kg' THEN (e.weight * e.sets * e.reps)::INTEGER
+                    //           WHEN e."weightUnit" = 'lb' THEN ((e.weight * 0.45359237) * e.sets * e.reps)::INTEGER
+                    //           ELSE 0
+                    //         END
+                    //       ) AS workCapacityKg
+                    //     FROM workouts w
+                    //     LEFT JOIN exercises e ON w.uid = e."workoutUid"
+                    //     WHERE w."userUid" = '${parent.uid}'
+                    //       AND w.date::date >= DATE(SPLIT_PART(:${dateRange}, ',', 1))::date
+                    //       AND w.date::date <= DATE(SPLIT_PART(:${dateRange}, ',', 2))::date
+                    //     GROUP BY w.date::date
+                    //   )
+                    //   SELECT
+                    //     TO_CHAR(dr.day, 'YYYY-MM-DD') || ',' || TO_CHAR(dr.day, 'YYYY-MM-DD') AS "dateRange",
+                    //     COALESCE(des.elapsedSeconds, 0) AS "elapsedSeconds",
+                    //     COALESCE(dwc.workCapacityKg, 0) AS "workCapacityKg"
+                    //   FROM date_range dr
+                    //   LEFT JOIN daily_elapsed_seconds des ON dr.day = des.date
+                    //   LEFT JOIN daily_work_capacity dwc ON dr.day = dwc.date
+                    //   ORDER BY dr.day;
+                    // `)
+                    // ).rows;
                     const weeklyData = (await knexInstance.raw(`
-            WITH date_range AS (
-              SELECT generate_series(
-                date_trunc('week', CURRENT_DATE)::date,
-                date_trunc('week', CURRENT_DATE)::date + interval '6 days',
-                interval '1 day'
-              )::date AS day
-            ),
-            daily_elapsed_seconds AS (
-              SELECT 
-                w.date::date,
-                SUM(w."elapsedSeconds") AS elapsedSeconds
-              FROM workouts w
-              WHERE w."userUid" = '${parent.uid}'
-                AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
-                AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
-              GROUP BY w.date::date
-            ),
-            daily_work_capacity AS (
-              SELECT 
-                w.date::date,
-                SUM(
-                  CASE 
-                    WHEN e."weightUnit" = 'kg' THEN (e.weight * e.sets * e.reps)::INTEGER
-                    WHEN e."weightUnit" = 'lb' THEN ((e.weight * 0.45359237) * e.sets * e.reps)::INTEGER
-                    ELSE 0
-                  END
-                ) AS workCapacityKg
-              FROM workouts w
-              LEFT JOIN exercises e ON w.uid = e."workoutUid"
-              WHERE w."userUid" = '${parent.uid}'
-                AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
-                AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
-              GROUP BY w.date::date
-            )
-            SELECT 
-              TO_CHAR(dr.day, 'YYYY-MM-DD') || ',' || TO_CHAR(dr.day, 'YYYY-MM-DD') AS "dateRange",
-              COALESCE(des.elapsedSeconds, 0) AS "elapsedSeconds",
-              COALESCE(dwc.workCapacityKg, 0) AS "workCapacityKg"
-            FROM date_range dr
-            LEFT JOIN daily_elapsed_seconds des ON dr.day = des.date
-            LEFT JOIN daily_work_capacity dwc ON dr.day = dwc.date
-            ORDER BY dr.day;
+              WITH date_range AS (
+                SELECT generate_series(
+                  date_trunc('week', CURRENT_DATE)::date,
+                  date_trunc('week', CURRENT_DATE)::date + interval '6 days',
+                  interval '1 day'
+                )::date AS day
+              ),
+              daily_elapsed_seconds AS (
+                SELECT
+                  w.date::date,
+                  SUM(w."elapsedSeconds") AS elapsedSeconds
+                FROM workouts w
+                WHERE w."userUid" = '${parent.uid}'
+                  AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
+                  AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
+                GROUP BY w.date::date
+              ),
+              daily_work_capacity AS (
+                SELECT
+                  w.date::date,
+                  SUM(
+                    CASE
+                      WHEN e."weightUnit" = 'kg' THEN (e.weight * e.sets * e.reps)::INTEGER
+                      WHEN e."weightUnit" = 'lb' THEN ((e.weight * 0.45359237) * e.sets * e.reps)::INTEGER
+                      ELSE 0
+                    END
+                  ) AS workCapacityKg
+                FROM workouts w
+                LEFT JOIN exercises e ON w.uid = e."workoutUid"
+                WHERE w."userUid" = '${parent.uid}'
+                  AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
+                  AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
+                GROUP BY w.date::date
+              )
+              SELECT
+                TO_CHAR(dr.day, 'YYYY-MM-DD') || ',' || TO_CHAR(dr.day, 'YYYY-MM-DD') AS "dateRange",
+                COALESCE(des.elapsedSeconds, 0) AS "elapsedSeconds",
+                COALESCE(dwc.workCapacityKg, 0) AS "workCapacityKg"
+              FROM date_range dr
+              LEFT JOIN daily_elapsed_seconds des ON dr.day = des.date
+              LEFT JOIN daily_work_capacity dwc ON dr.day = dwc.date
+              ORDER BY dr.day;
             `)).rows;
                     const weeklyDateRange = getRangeFromData(weeklyData);
                     return {

--- a/backend/graphql-server/dist/resolvers.js
+++ b/backend/graphql-server/dist/resolvers.js
@@ -253,57 +253,11 @@ export const resolvers = {
                 case "Week":
                 default:
                     const weeklyPeriod = "weekly";
-                    // const weeklyData: AtAGlanceData[] = (
-                    //   await knexInstance.raw(`
-                    //   WITH date_range AS (
-                    //     SELECT generate_series(
-                    //       DATE(SPLIT_PART(:${dateRange}, ',', 1))::date,
-                    //       DATE(SPLIT_PART(:${dateRange}, ',', 2))::date,
-                    //       interval '1 day'
-                    //     )::date AS day
-                    //   ),
-                    //   daily_elapsed_seconds AS (
-                    //     SELECT
-                    //       w.date::date,
-                    //       SUM(w."elapsedSeconds") AS elapsedSeconds
-                    //     FROM workouts w
-                    //     WHERE w."userUid" = '${parent.uid}'
-                    //       AND w.date::date >= DATE(SPLIT_PART(:${dateRange}, ',', 1))::date
-                    //       AND w.date::date <= DATE(SPLIT_PART(:${dateRange}, ',', 2))::date
-                    //     GROUP BY w.date::date
-                    //   ),
-                    //   daily_work_capacity AS (
-                    //     SELECT
-                    //       w.date::date,
-                    //       SUM(
-                    //         CASE
-                    //           WHEN e."weightUnit" = 'kg' THEN (e.weight * e.sets * e.reps)::INTEGER
-                    //           WHEN e."weightUnit" = 'lb' THEN ((e.weight * 0.45359237) * e.sets * e.reps)::INTEGER
-                    //           ELSE 0
-                    //         END
-                    //       ) AS workCapacityKg
-                    //     FROM workouts w
-                    //     LEFT JOIN exercises e ON w.uid = e."workoutUid"
-                    //     WHERE w."userUid" = '${parent.uid}'
-                    //       AND w.date::date >= DATE(SPLIT_PART(:${dateRange}, ',', 1))::date
-                    //       AND w.date::date <= DATE(SPLIT_PART(:${dateRange}, ',', 2))::date
-                    //     GROUP BY w.date::date
-                    //   )
-                    //   SELECT
-                    //     TO_CHAR(dr.day, 'YYYY-MM-DD') || ',' || TO_CHAR(dr.day, 'YYYY-MM-DD') AS "dateRange",
-                    //     COALESCE(des.elapsedSeconds, 0) AS "elapsedSeconds",
-                    //     COALESCE(dwc.workCapacityKg, 0) AS "workCapacityKg"
-                    //   FROM date_range dr
-                    //   LEFT JOIN daily_elapsed_seconds des ON dr.day = des.date
-                    //   LEFT JOIN daily_work_capacity dwc ON dr.day = dwc.date
-                    //   ORDER BY dr.day;
-                    // `)
-                    // ).rows;
                     const weeklyData = (await knexInstance.raw(`
               WITH date_range AS (
                 SELECT generate_series(
-                  date_trunc('week', CURRENT_DATE)::date,
-                  date_trunc('week', CURRENT_DATE)::date + interval '6 days',
+                  DATE(SPLIT_PART('${dateRange}', ',', 1))::date,
+                  DATE(SPLIT_PART('${dateRange}', ',', 2))::date,
                   interval '1 day'
                 )::date AS day
               ),
@@ -313,8 +267,8 @@ export const resolvers = {
                   SUM(w."elapsedSeconds") AS elapsedSeconds
                 FROM workouts w
                 WHERE w."userUid" = '${parent.uid}'
-                  AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
-                  AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
+                  AND w.date::date >= DATE(SPLIT_PART('${dateRange}', ',', 1))::date
+                  AND w.date::date <= DATE(SPLIT_PART('${dateRange}', ',', 2))::date
                 GROUP BY w.date::date
               ),
               daily_work_capacity AS (
@@ -330,8 +284,8 @@ export const resolvers = {
                 FROM workouts w
                 LEFT JOIN exercises e ON w.uid = e."workoutUid"
                 WHERE w."userUid" = '${parent.uid}'
-                  AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
-                  AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
+                  AND w.date::date >= DATE(SPLIT_PART('${dateRange}', ',', 1))::date
+                  AND w.date::date <= DATE(SPLIT_PART('${dateRange}', ',', 2))::date
                 GROUP BY w.date::date
               )
               SELECT

--- a/backend/graphql-server/src/resolvers.ts
+++ b/backend/graphql-server/src/resolvers.ts
@@ -295,59 +295,12 @@ export const resolvers = {
         case "Week":
         default:
           const weeklyPeriod = "weekly";
-          // const weeklyData: AtAGlanceData[] = (
-          //   await knexInstance.raw(`
-          //   WITH date_range AS (
-          //     SELECT generate_series(
-          //       DATE(SPLIT_PART(:${dateRange}, ',', 1))::date,
-          //       DATE(SPLIT_PART(:${dateRange}, ',', 2))::date,
-          //       interval '1 day'
-          //     )::date AS day
-          //   ),
-          //   daily_elapsed_seconds AS (
-          //     SELECT
-          //       w.date::date,
-          //       SUM(w."elapsedSeconds") AS elapsedSeconds
-          //     FROM workouts w
-          //     WHERE w."userUid" = '${parent.uid}'
-          //       AND w.date::date >= DATE(SPLIT_PART(:${dateRange}, ',', 1))::date
-          //       AND w.date::date <= DATE(SPLIT_PART(:${dateRange}, ',', 2))::date
-          //     GROUP BY w.date::date
-          //   ),
-          //   daily_work_capacity AS (
-          //     SELECT
-          //       w.date::date,
-          //       SUM(
-          //         CASE
-          //           WHEN e."weightUnit" = 'kg' THEN (e.weight * e.sets * e.reps)::INTEGER
-          //           WHEN e."weightUnit" = 'lb' THEN ((e.weight * 0.45359237) * e.sets * e.reps)::INTEGER
-          //           ELSE 0
-          //         END
-          //       ) AS workCapacityKg
-          //     FROM workouts w
-          //     LEFT JOIN exercises e ON w.uid = e."workoutUid"
-          //     WHERE w."userUid" = '${parent.uid}'
-          //       AND w.date::date >= DATE(SPLIT_PART(:${dateRange}, ',', 1))::date
-          //       AND w.date::date <= DATE(SPLIT_PART(:${dateRange}, ',', 2))::date
-          //     GROUP BY w.date::date
-          //   )
-          //   SELECT
-          //     TO_CHAR(dr.day, 'YYYY-MM-DD') || ',' || TO_CHAR(dr.day, 'YYYY-MM-DD') AS "dateRange",
-          //     COALESCE(des.elapsedSeconds, 0) AS "elapsedSeconds",
-          //     COALESCE(dwc.workCapacityKg, 0) AS "workCapacityKg"
-          //   FROM date_range dr
-          //   LEFT JOIN daily_elapsed_seconds des ON dr.day = des.date
-          //   LEFT JOIN daily_work_capacity dwc ON dr.day = dwc.date
-          //   ORDER BY dr.day;
-          // `)
-          // ).rows;
-
           const weeklyData: AtAGlanceData[] = (
             await knexInstance.raw(`
               WITH date_range AS (
                 SELECT generate_series(
-                  date_trunc('week', CURRENT_DATE)::date,
-                  date_trunc('week', CURRENT_DATE)::date + interval '6 days',
+                  DATE(SPLIT_PART('${dateRange}', ',', 1))::date,
+                  DATE(SPLIT_PART('${dateRange}', ',', 2))::date,
                   interval '1 day'
                 )::date AS day
               ),
@@ -357,8 +310,8 @@ export const resolvers = {
                   SUM(w."elapsedSeconds") AS elapsedSeconds
                 FROM workouts w
                 WHERE w."userUid" = '${parent.uid}'
-                  AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
-                  AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
+                  AND w.date::date >= DATE(SPLIT_PART('${dateRange}', ',', 1))::date
+                  AND w.date::date <= DATE(SPLIT_PART('${dateRange}', ',', 2))::date
                 GROUP BY w.date::date
               ),
               daily_work_capacity AS (
@@ -374,8 +327,8 @@ export const resolvers = {
                 FROM workouts w
                 LEFT JOIN exercises e ON w.uid = e."workoutUid"
                 WHERE w."userUid" = '${parent.uid}'
-                  AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
-                  AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
+                  AND w.date::date >= DATE(SPLIT_PART('${dateRange}', ',', 1))::date
+                  AND w.date::date <= DATE(SPLIT_PART('${dateRange}', ',', 2))::date
                 GROUP BY w.date::date
               )
               SELECT

--- a/backend/graphql-server/src/resolvers.ts
+++ b/backend/graphql-server/src/resolvers.ts
@@ -276,12 +276,12 @@ export const resolvers = {
       }
     },
     // period: "Week" | "Month" | "Year" | "Lifetime" --> the type of data queried.
-    // dateRange: "2021-01-01,2021-01-31" --> for custom date range, default is the latest. YYYY-MM-DD,YYYY-MM-DD
+    // dateRange: Must be of the form: "YYYY-MM-DD,YYYY-MM-DD"
     async atAGlance(
       parent: User,
       {
         period,
-        dateRange, // TODO: Implement custom date range
+        dateRange,
       }: { period: "Week" | "Month" | "Year" | "Lifetime"; dateRange: string }
     ) {
       function getRangeFromData(queriedData: AtAGlanceData[]) {

--- a/backend/graphql-server/src/resolvers.ts
+++ b/backend/graphql-server/src/resolvers.ts
@@ -295,50 +295,97 @@ export const resolvers = {
         case "Week":
         default:
           const weeklyPeriod = "weekly";
+          // const weeklyData: AtAGlanceData[] = (
+          //   await knexInstance.raw(`
+          //   WITH date_range AS (
+          //     SELECT generate_series(
+          //       DATE(SPLIT_PART(:${dateRange}, ',', 1))::date,
+          //       DATE(SPLIT_PART(:${dateRange}, ',', 2))::date,
+          //       interval '1 day'
+          //     )::date AS day
+          //   ),
+          //   daily_elapsed_seconds AS (
+          //     SELECT
+          //       w.date::date,
+          //       SUM(w."elapsedSeconds") AS elapsedSeconds
+          //     FROM workouts w
+          //     WHERE w."userUid" = '${parent.uid}'
+          //       AND w.date::date >= DATE(SPLIT_PART(:${dateRange}, ',', 1))::date
+          //       AND w.date::date <= DATE(SPLIT_PART(:${dateRange}, ',', 2))::date
+          //     GROUP BY w.date::date
+          //   ),
+          //   daily_work_capacity AS (
+          //     SELECT
+          //       w.date::date,
+          //       SUM(
+          //         CASE
+          //           WHEN e."weightUnit" = 'kg' THEN (e.weight * e.sets * e.reps)::INTEGER
+          //           WHEN e."weightUnit" = 'lb' THEN ((e.weight * 0.45359237) * e.sets * e.reps)::INTEGER
+          //           ELSE 0
+          //         END
+          //       ) AS workCapacityKg
+          //     FROM workouts w
+          //     LEFT JOIN exercises e ON w.uid = e."workoutUid"
+          //     WHERE w."userUid" = '${parent.uid}'
+          //       AND w.date::date >= DATE(SPLIT_PART(:${dateRange}, ',', 1))::date
+          //       AND w.date::date <= DATE(SPLIT_PART(:${dateRange}, ',', 2))::date
+          //     GROUP BY w.date::date
+          //   )
+          //   SELECT
+          //     TO_CHAR(dr.day, 'YYYY-MM-DD') || ',' || TO_CHAR(dr.day, 'YYYY-MM-DD') AS "dateRange",
+          //     COALESCE(des.elapsedSeconds, 0) AS "elapsedSeconds",
+          //     COALESCE(dwc.workCapacityKg, 0) AS "workCapacityKg"
+          //   FROM date_range dr
+          //   LEFT JOIN daily_elapsed_seconds des ON dr.day = des.date
+          //   LEFT JOIN daily_work_capacity dwc ON dr.day = dwc.date
+          //   ORDER BY dr.day;
+          // `)
+          // ).rows;
+
           const weeklyData: AtAGlanceData[] = (
             await knexInstance.raw(`
-            WITH date_range AS (
-              SELECT generate_series(
-                date_trunc('week', CURRENT_DATE)::date,
-                date_trunc('week', CURRENT_DATE)::date + interval '6 days',
-                interval '1 day'
-              )::date AS day
-            ),
-            daily_elapsed_seconds AS (
-              SELECT 
-                w.date::date,
-                SUM(w."elapsedSeconds") AS elapsedSeconds
-              FROM workouts w
-              WHERE w."userUid" = '${parent.uid}'
-                AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
-                AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
-              GROUP BY w.date::date
-            ),
-            daily_work_capacity AS (
-              SELECT 
-                w.date::date,
-                SUM(
-                  CASE 
-                    WHEN e."weightUnit" = 'kg' THEN (e.weight * e.sets * e.reps)::INTEGER
-                    WHEN e."weightUnit" = 'lb' THEN ((e.weight * 0.45359237) * e.sets * e.reps)::INTEGER
-                    ELSE 0
-                  END
-                ) AS workCapacityKg
-              FROM workouts w
-              LEFT JOIN exercises e ON w.uid = e."workoutUid"
-              WHERE w."userUid" = '${parent.uid}'
-                AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
-                AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
-              GROUP BY w.date::date
-            )
-            SELECT 
-              TO_CHAR(dr.day, 'YYYY-MM-DD') || ',' || TO_CHAR(dr.day, 'YYYY-MM-DD') AS "dateRange",
-              COALESCE(des.elapsedSeconds, 0) AS "elapsedSeconds",
-              COALESCE(dwc.workCapacityKg, 0) AS "workCapacityKg"
-            FROM date_range dr
-            LEFT JOIN daily_elapsed_seconds des ON dr.day = des.date
-            LEFT JOIN daily_work_capacity dwc ON dr.day = dwc.date
-            ORDER BY dr.day;
+              WITH date_range AS (
+                SELECT generate_series(
+                  date_trunc('week', CURRENT_DATE)::date,
+                  date_trunc('week', CURRENT_DATE)::date + interval '6 days',
+                  interval '1 day'
+                )::date AS day
+              ),
+              daily_elapsed_seconds AS (
+                SELECT
+                  w.date::date,
+                  SUM(w."elapsedSeconds") AS elapsedSeconds
+                FROM workouts w
+                WHERE w."userUid" = '${parent.uid}'
+                  AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
+                  AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
+                GROUP BY w.date::date
+              ),
+              daily_work_capacity AS (
+                SELECT
+                  w.date::date,
+                  SUM(
+                    CASE
+                      WHEN e."weightUnit" = 'kg' THEN (e.weight * e.sets * e.reps)::INTEGER
+                      WHEN e."weightUnit" = 'lb' THEN ((e.weight * 0.45359237) * e.sets * e.reps)::INTEGER
+                      ELSE 0
+                    END
+                  ) AS workCapacityKg
+                FROM workouts w
+                LEFT JOIN exercises e ON w.uid = e."workoutUid"
+                WHERE w."userUid" = '${parent.uid}'
+                  AND w.date::date >= date_trunc('week', CURRENT_DATE)::date
+                  AND w.date::date < (date_trunc('week', CURRENT_DATE) + interval '1 week')::date
+                GROUP BY w.date::date
+              )
+              SELECT
+                TO_CHAR(dr.day, 'YYYY-MM-DD') || ',' || TO_CHAR(dr.day, 'YYYY-MM-DD') AS "dateRange",
+                COALESCE(des.elapsedSeconds, 0) AS "elapsedSeconds",
+                COALESCE(dwc.workCapacityKg, 0) AS "workCapacityKg"
+              FROM date_range dr
+              LEFT JOIN daily_elapsed_seconds des ON dr.day = des.date
+              LEFT JOIN daily_work_capacity dwc ON dr.day = dwc.date
+              ORDER BY dr.day;
             `)
           ).rows;
           const weeklyDateRange = getRangeFromData(weeklyData);

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlance.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlance.tsx
@@ -19,6 +19,7 @@ import LoadingSpinner from "../../LoadingSpinner";
 import Graph from "./Visualization/Graph";
 import Detail from "../../ViewWorkouts/ViewDetailedWorkoutModal/Detail";
 import { formatTime } from "../../../utils/Time/time";
+import WeeklyRangeSelector from "./AtAGlanceSlider";
 
 export default function AtAGlance() {
   const [selectedPeriod, setSelectedPeriod] = React.useState<
@@ -157,24 +158,28 @@ export default function AtAGlance() {
           </Box>
         )}
       </VStack>
-      <HStack
-        mt="0.5rem"
-        mb="0rem"
-        justifyContent={"space-evenly"}
-        flexWrap="wrap"
-        gap="1rem"
-      >
-        <RadioGroup
-          items={periods}
-          selected={selectedPeriod}
-          handleClick={handlePeriodClick}
-        />
-        <RadioGroup
-          items={metrics}
-          selected={selectedMetric}
-          handleClick={handleMetricClick}
-        />
-      </HStack>
+      <VStack>
+        <HStack
+          mt="0.5rem"
+          mb="0rem"
+          justifyContent={"space-evenly"}
+          flexWrap="wrap"
+          gap="1rem"
+          w="100%"
+        >
+          <RadioGroup
+            items={periods}
+            selected={selectedPeriod}
+            handleClick={handlePeriodClick}
+          />
+          <RadioGroup
+            items={metrics}
+            selected={selectedMetric}
+            handleClick={handleMetricClick}
+          />
+          <WeeklyRangeSelector selectedPeriod={selectedPeriod} />
+        </HStack>
+      </VStack>
     </Box>
   );
 }

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlance.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlance.tsx
@@ -18,13 +18,19 @@ import { useUser } from "../../../Contexts/UserContext";
 import LoadingSpinner from "../../LoadingSpinner";
 import Graph from "./Visualization/Graph";
 import Detail from "../../ViewWorkouts/ViewDetailedWorkoutModal/Detail";
-import { formatTime } from "../../../utils/Time/time";
+import {
+  formatTime,
+  getMonSunYYYYMMDDOfCurrentWeek,
+} from "../../../utils/Time/time";
 import WeeklyRangeSelector from "./AtAGlanceSlider";
 
 export default function AtAGlance() {
   const [selectedPeriod, setSelectedPeriod] = React.useState<
     "Week" | "Month" | "Year" | "Lifetime"
   >("Week");
+  const [dateRange, setDateRange] = React.useState<string>(
+    selectedPeriod === "Week" ? getMonSunYYYYMMDDOfCurrentWeek() : "TODO"
+  );
   const periods = ["Week", "Month", "Year", "Lifetime"];
   const handlePeriodClick = (period: string) => {
     setSelectedPeriod(period as "Week" | "Month" | "Year" | "Lifetime");
@@ -43,7 +49,7 @@ export default function AtAGlance() {
     variables: {
       uid: user?.uid ?? "",
       period: selectedPeriod,
-      dateRange: "TODO",
+      dateRange: dateRange,
     },
   });
 
@@ -177,7 +183,10 @@ export default function AtAGlance() {
             selected={selectedMetric}
             handleClick={handleMetricClick}
           />
-          <WeeklyRangeSelector selectedPeriod={selectedPeriod} />
+          <WeeklyRangeSelector
+            dateRange={dateRange}
+            setDateRange={setDateRange}
+          />
         </HStack>
       </VStack>
     </Box>

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlance.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlance.tsx
@@ -22,7 +22,7 @@ import {
   formatTime,
   getMonSunYYYYMMDDOfCurrentWeek,
 } from "../../../utils/Time/time";
-import WeeklyRangeSelector from "./AtAGlanceSlider";
+import WeeklyRangeSelector from "./WeeklyRangeSelector";
 
 export default function AtAGlance() {
   const [selectedPeriod, setSelectedPeriod] = React.useState<
@@ -183,10 +183,12 @@ export default function AtAGlance() {
             selected={selectedMetric}
             handleClick={handleMetricClick}
           />
-          <WeeklyRangeSelector
-            dateRange={dateRange}
-            setDateRange={setDateRange}
-          />
+          {selectedPeriod === "Week" && (
+            <WeeklyRangeSelector
+              dateRange={dateRange}
+              setDateRange={setDateRange}
+            />
+          )}
         </HStack>
       </VStack>
     </Box>

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlanceSlider.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlanceSlider.tsx
@@ -4,9 +4,10 @@ import {
   RangeSliderFilledTrack,
   RangeSliderTrack,
   RangeSliderThumb,
-  RangeSliderMark,
+  Heading,
   HStack,
   IconButton,
+  VStack,
 } from "@chakra-ui/react";
 import theme from "../../../Constants/theme";
 import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
@@ -45,11 +46,7 @@ export default function WeeklyRangeSelector({
   };
 
   // Formats to "YYYY-MM-DD,YYYY-MM-DD" based on UI changes
-  const updateDateRange = (
-    newCenter: number,
-    newSliderMin: number,
-    newSliderMax: number
-  ) => {
+  const updateDateRange = (newSliderMin: number, newSliderMax: number) => {
     const formattedDateRange = createDateRangeString(
       newSliderMin,
       newSliderMax
@@ -67,7 +64,7 @@ export default function WeeklyRangeSelector({
     setMin((prevMin) => prevMin - 7);
     setMax((prevMax) => prevMax - 7);
     setSliderHandleValues([newSliderMin, newSliderMax]);
-    updateDateRange(newCenter, newSliderMin, newSliderMax);
+    updateDateRange(newSliderMin, newSliderMax);
   };
   // Shifts selected range one week ahead in time.
   const shiftRight = () => {
@@ -79,11 +76,11 @@ export default function WeeklyRangeSelector({
     setMin((prevMin) => prevMin + 7);
     setMax((prevMax) => prevMax + 7);
     setSliderHandleValues([newSliderMin, newSliderMax]);
-    updateDateRange(newCenter, newSliderMin, newSliderMax);
+    updateDateRange(newSliderMin, newSliderMax);
   };
 
   return (
-    <>
+    <VStack w="100%" spacing={0}>
       <HStack m="1.5rem 1rem" w="100%">
         <IconButton
           variant="secondary"
@@ -97,15 +94,11 @@ export default function WeeklyRangeSelector({
           value={sliderHandleValues}
           onChange={handleSliderChange}
           onChangeEnd={() =>
-            updateDateRange(
-              center,
-              sliderHandleValues[0],
-              sliderHandleValues[1]
-            )
+            updateDateRange(sliderHandleValues[0], sliderHandleValues[1])
           }
           min={min}
           max={max}
-          m="1rem"
+          mx="1rem"
         >
           <RangeSliderTrack>
             <RangeSliderFilledTrack bg={theme.colors.green[300]} />
@@ -126,26 +119,6 @@ export default function WeeklyRangeSelector({
               boxShadow: `0 0 0 3px ${theme.colors.green[50]}`,
             }}
           />
-
-          {/* <RangeSliderMark
-            value={sliderHandleValues[0]}
-            mt="3"
-            ml="-2.5"
-            fontSize="sm"
-          >
-            {sliderHandleValues[0]}
-          </RangeSliderMark>
-          <RangeSliderMark value={center} mt="3" ml="-2.5" fontSize="sm">
-            {center}
-          </RangeSliderMark>
-          <RangeSliderMark
-            value={sliderHandleValues[1]}
-            mt="3"
-            ml="-2.5"
-            fontSize="sm"
-          >
-            {sliderHandleValues[1]}
-          </RangeSliderMark> */}
         </RangeSlider>
 
         <IconButton
@@ -156,7 +129,9 @@ export default function WeeklyRangeSelector({
           onClick={shiftRight}
         />
       </HStack>
-      <h2>{dateRange}</h2>
-    </>
+      <Heading size="sm" m="-0.25rem 0 0.75rem 0">{`${
+        dateRange.split(",")[0]
+      } - ${dateRange.split(",")[1]}`}</Heading>
+    </VStack>
   );
 }

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlanceSlider.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlanceSlider.tsx
@@ -10,9 +10,11 @@ import {
 } from "@chakra-ui/react";
 import theme from "../../../Constants/theme";
 import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
+import { createDateRangeString } from "../../../utils/Time/time";
 
 interface WeeklyRangeSelectorProps {
-  selectedPeriod: "Week" | "Month" | "Year" | "Lifetime";
+  dateRange: string;
+  setDateRange: (newDateRange: string) => void;
 }
 /**
  * WEEKLY *
@@ -26,108 +28,135 @@ Since slider values are numbers we can use dayjs to add/subtract the offset from
 
 */
 export default function WeeklyRangeSelector({
-  selectedPeriod,
+  dateRange,
+  setDateRange,
 }: WeeklyRangeSelectorProps) {
   const [center, setCenter] = useState<number>(0);
   const [sliderHandleValues, setSliderHandleValues] = useState<number[]>([
     center - 3,
     center + 3,
   ]);
-  const min = -7;
-  const max = 7;
+  const [min, setMin] = useState(-7);
+  const [max, setMax] = useState(7);
 
+  // Adjusts view in daily increments. 15 days is maximally viewable.
   const handleSliderChange = (newValues: number[]) => {
     setSliderHandleValues(newValues);
   };
 
-  const refetch = () => {
-    console.log("done changing");
+  // Formats to "YYYY-MM-DD,YYYY-MM-DD" based on UI changes
+  const updateDateRange = (
+    newCenter: number,
+    newSliderMin: number,
+    newSliderMax: number
+  ) => {
+    const formattedDateRange = createDateRangeString(
+      newSliderMin,
+      newSliderMax
+    );
+    setDateRange(formattedDateRange);
   };
 
+  // Shifts selected range one week back in time.
   const shiftLeft = () => {
-    setCenter((prevCenter) => prevCenter - 1);
-    setSliderHandleValues([
-      sliderHandleValues[0] - 1,
-      sliderHandleValues[1] - 1,
-    ]);
-    refetch();
+    const newCenter = center - 7;
+    const newSliderMin = sliderHandleValues[0] - 7;
+    const newSliderMax = sliderHandleValues[1] - 7;
+
+    setCenter(newCenter);
+    setMin((prevMin) => prevMin - 7);
+    setMax((prevMax) => prevMax - 7);
+    setSliderHandleValues([newSliderMin, newSliderMax]);
+    updateDateRange(newCenter, newSliderMin, newSliderMax);
   };
+  // Shifts selected range one week ahead in time.
   const shiftRight = () => {
-    setCenter((prevCenter) => prevCenter + 1);
-    setSliderHandleValues([
-      sliderHandleValues[0] + 1,
-      sliderHandleValues[1] + 1,
-    ]);
-    refetch();
+    const newCenter = center + 7;
+    const newSliderMin = sliderHandleValues[0] + 7;
+    const newSliderMax = sliderHandleValues[1] + 7;
+
+    setCenter(newCenter);
+    setMin((prevMin) => prevMin + 7);
+    setMax((prevMax) => prevMax + 7);
+    setSliderHandleValues([newSliderMin, newSliderMax]);
+    updateDateRange(newCenter, newSliderMin, newSliderMax);
   };
 
   return (
-    <HStack m="1.5rem 1rem" w="100%">
-      <IconButton
-        variant="secondary"
-        aria-label="One week back"
-        size="sm"
-        icon={<FaArrowLeft />}
-        onClick={shiftLeft}
-        isDisabled={sliderHandleValues[0] === min}
-      />
-      <RangeSlider
-        aria-label={["min", "max"]}
-        value={sliderHandleValues}
-        onChange={handleSliderChange}
-        onChangeEnd={refetch}
-        min={min}
-        max={max}
-        m="1rem"
-      >
-        <RangeSliderTrack>
-          <RangeSliderFilledTrack bg={theme.colors.green[300]} />
-        </RangeSliderTrack>
-        <RangeSliderThumb
-          boxSize={6}
-          index={0}
-          bgColor={theme.colors.feldgrau[200]}
-          _focus={{
-            boxShadow: `0 0 0 3px ${theme.colors.green[50]}`,
-          }}
+    <>
+      <HStack m="1.5rem 1rem" w="100%">
+        <IconButton
+          variant="secondary"
+          aria-label="Shift graph one week back"
+          size="sm"
+          icon={<FaArrowLeft />}
+          onClick={shiftLeft}
         />
-        <RangeSliderThumb
-          boxSize={6}
-          index={1}
-          bgColor={theme.colors.feldgrau[200]}
-          _focus={{
-            boxShadow: `0 0 0 3px ${theme.colors.green[50]}`,
-          }}
-        />
+        <RangeSlider
+          aria-label={["min", "max"]}
+          value={sliderHandleValues}
+          onChange={handleSliderChange}
+          onChangeEnd={() =>
+            updateDateRange(
+              center,
+              sliderHandleValues[0],
+              sliderHandleValues[1]
+            )
+          }
+          min={min}
+          max={max}
+          m="1rem"
+        >
+          <RangeSliderTrack>
+            <RangeSliderFilledTrack bg={theme.colors.green[300]} />
+          </RangeSliderTrack>
+          <RangeSliderThumb
+            boxSize={6}
+            index={0}
+            bgColor={theme.colors.feldgrau[200]}
+            _focus={{
+              boxShadow: `0 0 0 3px ${theme.colors.green[50]}`,
+            }}
+          />
+          <RangeSliderThumb
+            boxSize={6}
+            index={1}
+            bgColor={theme.colors.feldgrau[200]}
+            _focus={{
+              boxShadow: `0 0 0 3px ${theme.colors.green[50]}`,
+            }}
+          />
 
-        <RangeSliderMark
-          value={sliderHandleValues[0]}
-          mt="3"
-          ml="-2.5"
-          fontSize="sm"
-        >
-          {sliderHandleValues[0]}
-        </RangeSliderMark>
-        <RangeSliderMark value={center} mt="3" ml="-2.5" fontSize="sm">
-          {center}
-        </RangeSliderMark>
-        <RangeSliderMark
-          value={sliderHandleValues[1]}
-          mt="3"
-          ml="-2.5"
-          fontSize="sm"
-        >
-          {sliderHandleValues[1]}
-        </RangeSliderMark>
-      </RangeSlider>
-      <IconButton
-        variant="secondary"
-        aria-label="One week forward"
-        size="sm"
-        icon={<FaArrowRight />}
-        onClick={shiftRight}
-        isDisabled={sliderHandleValues[1] === max}
-      />
-    </HStack>
+          {/* <RangeSliderMark
+            value={sliderHandleValues[0]}
+            mt="3"
+            ml="-2.5"
+            fontSize="sm"
+          >
+            {sliderHandleValues[0]}
+          </RangeSliderMark>
+          <RangeSliderMark value={center} mt="3" ml="-2.5" fontSize="sm">
+            {center}
+          </RangeSliderMark>
+          <RangeSliderMark
+            value={sliderHandleValues[1]}
+            mt="3"
+            ml="-2.5"
+            fontSize="sm"
+          >
+            {sliderHandleValues[1]}
+          </RangeSliderMark> */}
+        </RangeSlider>
+
+        <IconButton
+          variant="secondary"
+          aria-label="Shift graph one week forward"
+          size="sm"
+          icon={<FaArrowRight />}
+          onClick={shiftRight}
+        />
+      </HStack>
+      <h2>{dateRange}</h2>
+    </>
   );
 }

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlanceSlider.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/AtAGlanceSlider.tsx
@@ -1,0 +1,133 @@
+import React, { useState } from "react";
+import {
+  RangeSlider,
+  RangeSliderFilledTrack,
+  RangeSliderTrack,
+  RangeSliderThumb,
+  RangeSliderMark,
+  HStack,
+  IconButton,
+} from "@chakra-ui/react";
+import theme from "../../../Constants/theme";
+import { FaArrowLeft, FaArrowRight } from "react-icons/fa";
+
+interface WeeklyRangeSelectorProps {
+  selectedPeriod: "Week" | "Month" | "Year" | "Lifetime";
+}
+/**
+ * WEEKLY *
+The center of the range slider is at value = 0. 
+The min and max of the range slider are +/-7 days from the center. Meaning the user
+can see up to 2 weeks of "days" at a time.  Since the slider starts at -3, 3 by default, they see Mon-Sun.
+By dragging the slider, additional days will come into view.
+
+To shift the entire time scale left or right, the user can click the left or right arrow buttons respectively.
+Since slider values are numbers we can use dayjs to add/subtract the offset from 0 before requerying the DB for updates.
+
+*/
+export default function WeeklyRangeSelector({
+  selectedPeriod,
+}: WeeklyRangeSelectorProps) {
+  const [center, setCenter] = useState<number>(0);
+  const [sliderHandleValues, setSliderHandleValues] = useState<number[]>([
+    center - 3,
+    center + 3,
+  ]);
+  const min = -7;
+  const max = 7;
+
+  const handleSliderChange = (newValues: number[]) => {
+    setSliderHandleValues(newValues);
+  };
+
+  const refetch = () => {
+    console.log("done changing");
+  };
+
+  const shiftLeft = () => {
+    setCenter((prevCenter) => prevCenter - 1);
+    setSliderHandleValues([
+      sliderHandleValues[0] - 1,
+      sliderHandleValues[1] - 1,
+    ]);
+    refetch();
+  };
+  const shiftRight = () => {
+    setCenter((prevCenter) => prevCenter + 1);
+    setSliderHandleValues([
+      sliderHandleValues[0] + 1,
+      sliderHandleValues[1] + 1,
+    ]);
+    refetch();
+  };
+
+  return (
+    <HStack m="1.5rem 1rem" w="100%">
+      <IconButton
+        variant="secondary"
+        aria-label="One week back"
+        size="sm"
+        icon={<FaArrowLeft />}
+        onClick={shiftLeft}
+        isDisabled={sliderHandleValues[0] === min}
+      />
+      <RangeSlider
+        aria-label={["min", "max"]}
+        value={sliderHandleValues}
+        onChange={handleSliderChange}
+        onChangeEnd={refetch}
+        min={min}
+        max={max}
+        m="1rem"
+      >
+        <RangeSliderTrack>
+          <RangeSliderFilledTrack bg={theme.colors.green[300]} />
+        </RangeSliderTrack>
+        <RangeSliderThumb
+          boxSize={6}
+          index={0}
+          bgColor={theme.colors.feldgrau[200]}
+          _focus={{
+            boxShadow: `0 0 0 3px ${theme.colors.green[50]}`,
+          }}
+        />
+        <RangeSliderThumb
+          boxSize={6}
+          index={1}
+          bgColor={theme.colors.feldgrau[200]}
+          _focus={{
+            boxShadow: `0 0 0 3px ${theme.colors.green[50]}`,
+          }}
+        />
+
+        <RangeSliderMark
+          value={sliderHandleValues[0]}
+          mt="3"
+          ml="-2.5"
+          fontSize="sm"
+        >
+          {sliderHandleValues[0]}
+        </RangeSliderMark>
+        <RangeSliderMark value={center} mt="3" ml="-2.5" fontSize="sm">
+          {center}
+        </RangeSliderMark>
+        <RangeSliderMark
+          value={sliderHandleValues[1]}
+          mt="3"
+          ml="-2.5"
+          fontSize="sm"
+        >
+          {sliderHandleValues[1]}
+        </RangeSliderMark>
+      </RangeSlider>
+      <IconButton
+        variant="secondary"
+        aria-label="One week forward"
+        size="sm"
+        icon={<FaArrowRight />}
+        onClick={shiftRight}
+        isDisabled={sliderHandleValues[1] === max}
+      />
+    </HStack>
+  );
+}

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/Visualization/Graph.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/Visualization/Graph.tsx
@@ -3,6 +3,7 @@ import * as d3 from "d3";
 import { AtAGlanceQuery } from "../../../../generated/frontend-types";
 import theme from "../../../../Constants/theme";
 import Tooltip from "./Tooltip";
+import { useMediaQuery } from "@chakra-ui/react";
 
 type AtAGlanceData = NonNullable<
   NonNullable<NonNullable<AtAGlanceQuery["user"]>["atAGlance"]>["data"]
@@ -40,12 +41,27 @@ export default function Graph({ data, period, visualizeField }: GraphProps) {
       | "elapsedSeconds"
       | "workCapacityKg") ?? "elapsedSeconds";
 
+  const [isSmallScreen] = useMediaQuery("(max-width: 1200px)");
+
   useEffect(() => {
     if (!data || data.length === 0 || !svgRef.current) return;
 
     ///////////////////////////// Prepare Data & Labels /////////////////////////////////////
 
-    const dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+    const dayLabels = data.map((entry, i) => {
+      const date = new Date(entry?.dateRange.split(",")[0] + ":12:00" ?? "");
+      return date.toLocaleDateString(
+        "en-US",
+        isSmallScreen
+          ? data.length > 7
+            ? { day: "numeric" }
+            : { weekday: "short" }
+          : data.length > 7
+          ? { month: "short", day: "numeric" }
+          : { weekday: "short", month: "short", day: "numeric" }
+      );
+    });
+
     const weekLabels = data.map((entry, index) => `Week ${index + 1}`);
     const monthLabels = [
       "Jan",
@@ -325,7 +341,14 @@ export default function Graph({ data, period, visualizeField }: GraphProps) {
 
     // Add y axis
     svgGroup.append("g").call(d3.axisLeft(y));
-  }, [data, visualizeField, visualizationField, period, MAX_SECONDS]);
+  }, [
+    data,
+    visualizeField,
+    visualizationField,
+    period,
+    MAX_SECONDS,
+    isSmallScreen,
+  ]);
 
   return (
     <div style={{ position: "relative" }}>

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/Visualization/Tooltip.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/Visualization/Tooltip.tsx
@@ -27,7 +27,12 @@ export default function Tooltip({ content, position }: TooltipProps) {
         <Text>
           <b>Date:</b>{" "}
           {content.startDate.getTime() === content.endDate.getTime()
-            ? formatDate(content.startDate)
+            ? content.startDate.toLocaleDateString("en-us", {
+                weekday: "short",
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })
             : `${formatDate(content.startDate)} - ${formatDate(
                 content.endDate
               )}`}

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/WeeklyRangeSelector.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/WeeklyRangeSelector.tsx
@@ -89,7 +89,6 @@ export default function WeeklyRangeSelector({
           onClick={shiftLeft}
         />
         <RangeSlider
-          aria-label={["min", "max"]}
           value={sliderHandleValues}
           onChange={handleSliderChange}
           onChangeEnd={() =>

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/WeeklyRangeSelector.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/WeeklyRangeSelector.tsx
@@ -17,17 +17,16 @@ interface WeeklyRangeSelectorProps {
   dateRange: string;
   setDateRange: (newDateRange: string) => void;
 }
+
 /**
- * WEEKLY *
-The center of the range slider is at value = 0. 
-The min and max of the range slider are +/-7 days from the center. Meaning the user
-can see up to 2 weeks of "days" at a time.  Since the slider starts at -3, 3 by default, they see Mon-Sun.
-By dragging the slider, additional days will come into view.
-
-To shift the entire time scale left or right, the user can click the left or right arrow buttons respectively.
-Since slider values are numbers we can use dayjs to add/subtract the offset from 0 before requerying the DB for updates.
-
-*/
+ * The center of the range slider is at value = 0.
+ * The min and max of the range slider are +/-7 days from the center. Meaning the user
+ * can see a max of 2 weeks of data" at a time.  Since the slider starts at -3, 3 by default,
+ * they see Mon-Sun. By dragging the slider, additional days will come into view.
+ *
+ * To shift the entire time 'window' left or right by one week, the user can click the
+ * arrows on the left and right of the slider respectively.
+ */
 export default function WeeklyRangeSelector({
   dateRange,
   setDateRange,

--- a/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/WeeklyRangeSelector.tsx
+++ b/frontend/kettlepal-fe/src/Components/Profile/AtAGlance/WeeklyRangeSelector.tsx
@@ -21,8 +21,8 @@ interface WeeklyRangeSelectorProps {
 /**
  * The center of the range slider is at value = 0.
  * The min and max of the range slider are +/-7 days from the center. Meaning the user
- * can see a max of 2 weeks of data" at a time.  Since the slider starts at -3, 3 by default,
- * they see Mon-Sun. By dragging the slider, additional days will come into view.
+ * can see a max of 2 weeks of data at a time.  Since the slider is initialized at -3, 3,
+ * they see Mon-Sun. By dragging the slider, additional days will come & go from view.
  *
  * To shift the entire time 'window' left or right by one week, the user can click the
  * arrows on the left and right of the slider respectively.

--- a/frontend/kettlepal-fe/src/Constants/theme.ts
+++ b/frontend/kettlepal-fe/src/Constants/theme.ts
@@ -124,6 +124,16 @@ const theme = extendTheme({
         },
       },
     },
+    IconButton: {
+      variants: {
+        primary: (props: any) => ({
+          ...theme.components.Button.variants.primary(props),
+        }),
+        secondary: (props: any) => ({
+          ...theme.components.Button.variants.secondary(props),
+        }),
+      },
+    },
     Editable: {
       padding: "0rem",
       baseStyle: {

--- a/frontend/kettlepal-fe/src/utils/Time/time.ts
+++ b/frontend/kettlepal-fe/src/utils/Time/time.ts
@@ -1,6 +1,9 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
+import isoWeek from "dayjs/plugin/isoWeek";
+
+dayjs.extend(isoWeek);
 
 // Postgres timestamps are in UTC
 dayjs.extend(utc);
@@ -236,4 +239,30 @@ export function formatDate(date: Date) {
   };
 
   return `${month} ${day}${suffix(day)}, ${year}`;
+}
+
+// YYYY-MM-DD,YYYY-MM-DD of the current week. Mon-Sun.
+export function getMonSunYYYYMMDDOfCurrentWeek() {
+  const today = dayjs();
+  const monday = today.startOf("isoWeek");
+  const sunday = today.endOf("isoWeek");
+
+  const mondayFormatted = monday.format("YYYY-MM-DD");
+  const sundayFormatted = sunday.format("YYYY-MM-DD");
+
+  return `${mondayFormatted},${sundayFormatted}`;
+}
+
+/**
+ * @param min The number of days ahead or behind today
+ * @param max The number of days ahead or behind today
+ * @returns A string in the format "YYYY-MM-DD,YYYY-MM-DD" representing the "MIN,MAX" date range.
+ */
+export function createDateRangeString(min: number, max: number) {
+  const centerDate = dayjs().isoWeekday(4);
+  const minDate = centerDate.add(min, "day");
+  const maxDate = centerDate.add(max, "day");
+  const formattedMinDate = minDate.format("YYYY-MM-DD");
+  const formattedMaxDate = maxDate.format("YYYY-MM-DD");
+  return `${formattedMinDate},${formattedMaxDate}`;
 }


### PR DESCRIPTION
Updates the Weekly AtAGlance view to allow the user granular control over the days in the visualziation.

- My dragging the slider, they can add/remove days from the visualization, up to a maximum of 15 days at a time
- By clicking the forward/back buttons, they can shift the window in time one week ahead/back respectively.

#### Demo
https://github.com/user-attachments/assets/792fd2c8-bb3f-4632-adbe-e34fd63b8e9a

**Next Up**
Create similar contorls for the monthly, annual and lifetime visualizations.