### PR TITLE
Update exercise indicies for workout tracking

### DIFF
--- a/frontend/kettlepal-fe/src/Components/NewWorkouts/CreateExercise.tsx
+++ b/frontend/kettlepal-fe/src/Components/NewWorkouts/CreateExercise.tsx
@@ -20,6 +20,7 @@ interface CreateExerciseProps {
   handleExercise: (name: string, value: string | number, index: number) => void;
   deleteExercise: ((index: number) => void) | (() => Promise<void>);
   exerciseIndex: number;
+  trackingIndex: number;
   submitted: boolean;
   setFormHasErrors: (value: boolean) => void;
   trackWorkout: boolean;
@@ -32,6 +33,7 @@ export default function CreateExercise({
   handleExercise,
   deleteExercise,
   exerciseIndex,
+  trackingIndex,
   submitted,
   setFormHasErrors,
   trackWorkout,
@@ -67,6 +69,7 @@ export default function CreateExercise({
   } = useCreateExerciseForm({
     exercise,
     exerciseIndex,
+    trackingIndex,
     handleExercise,
     deleteExercise,
     setFormHasErrors,

--- a/frontend/kettlepal-fe/src/Components/NewWorkouts/CreateWorkout.tsx
+++ b/frontend/kettlepal-fe/src/Components/NewWorkouts/CreateWorkout.tsx
@@ -204,6 +204,7 @@ export default function CreateWorkout() {
                   handleExercise={handleExercise}
                   deleteExercise={deleteExercise}
                   exerciseIndex={index}
+                  trackingIndex={state.exercises.length - index - 1}
                   submitted={submitted}
                   setFormHasErrors={setFormHasErrors}
                   trackWorkout={showTracking}

--- a/frontend/kettlepal-fe/src/Components/NewWorkouts/FormComponents.tsx/MidWorkoutTracking/TrackExercise.tsx
+++ b/frontend/kettlepal-fe/src/Components/NewWorkouts/FormComponents.tsx/MidWorkoutTracking/TrackExercise.tsx
@@ -17,7 +17,6 @@ export default function TrackExercise({
   removedASet,
   completedASet,
 }: TrackExerciseProps) {
-
   return (
     <>
       {trackWorkout && (

--- a/frontend/kettlepal-fe/src/Components/ViewWorkouts/ViewDetailedWorkoutModal/EditWorkout.tsx
+++ b/frontend/kettlepal-fe/src/Components/ViewWorkouts/ViewDetailedWorkoutModal/EditWorkout.tsx
@@ -154,6 +154,7 @@ export default function EditWorkout({
                   handleExercise={handleExercise}
                   deleteExercise={deleteExercise}
                   exerciseIndex={index}
+                  trackingIndex={state.exercises.length - index - 1}
                   submitted={submitted}
                   setFormHasErrors={setFormHasErrors}
                   trackWorkout={false}

--- a/frontend/kettlepal-fe/src/Hooks/useCreateWorkoutForm.ts
+++ b/frontend/kettlepal-fe/src/Hooks/useCreateWorkoutForm.ts
@@ -125,6 +125,11 @@ const useCreateWorkoutForm = () => {
       ...prevState,
       [name]: value,
     }));
+
+    // If you change the date with no exercises, reset workout tracking (stale browser tab).
+    if (name === "date" && state.exercises.length === 0) {
+      deleteExerciseTrackingFromSessionStorage();
+    }
   }
 
   // Initialize a new exercise object

--- a/frontend/kettlepal-fe/src/Hooks/useCreateWorkoutForm.ts
+++ b/frontend/kettlepal-fe/src/Hooks/useCreateWorkoutForm.ts
@@ -197,6 +197,20 @@ const useCreateWorkoutForm = () => {
     [numErrors, setFormHasErrors]
   );
 
+  /**
+   * Deletes all 'completedSets-#' key-val pairs from sessionStorage, used for traacking a workout.
+   */
+  function deleteExerciseTrackingFromSessionStorage(): void {
+    const PREFIX = "completedSets-";
+
+    for (let i = 0; i < sessionStorage.length - 1; i++) {
+      const key = sessionStorage.key(i);
+      if (key?.startsWith(PREFIX)) {
+        sessionStorage.removeItem(key);
+      }
+    }
+  }
+
   // Show client-side errors, if clear, try to post to DB
   // apollo onError will handle rendering server-side errors
   async function onSaveWorkout(): Promise<void> {
@@ -216,6 +230,7 @@ const useCreateWorkoutForm = () => {
           workoutWithExercises: state,
         },
       });
+      deleteExerciseTrackingFromSessionStorage();
     } catch (err) {
       console.error("Error submitting workout with exercises: ", err);
     }


### PR DESCRIPTION
After reversing indicies for a new workout, the index tracking for completing a workout became out of sync. This PR addresses that updating the sessionStorage, and ensuring it consitent with state. It also resets workout tracking when a uses saves the current workout, or when a browser tab is stale (users updates the 'date' field before adding exercises).

`exerciseIndex` = the actual index of the exercise in state, used for all data-related references.
`trackingIndex` = the reversed indices, which represent the users perspective when tracking a current workout.
